### PR TITLE
Automatic installation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@ This helps ensure that your books are successfully synced and prevents any poten
 
 **⚠️ If you follow all the instructions but installation fails, please open an installation issue.**
 
+### Automatic install
+
+```console
+$ sh ./hello_toutui.sh install
+```
+
 ### For Arch Users
 🚧 Soon
 
@@ -96,6 +102,12 @@ cd target/release
 #### **Update:**
 
 When a new release is available, follow these steps:
+
+```console
+$ sh ./hello_toutui.sh update
+```
+
+or
 
 ```bash
 git pull https://github.com/AlbanDAVID/Toutui

--- a/hello_toutui.sh
+++ b/hello_toutui.sh
@@ -1,0 +1,362 @@
+#!/usr/bin/env bash
+# Install Toutui and dependencies automagically.
+
+main() {
+    do_not_run_as_root
+
+    # Grab essential variables
+    USER=${USER:-$(grab_username)}
+    HOME=${HOME:-$(grab_home_dir)}
+    CONFIG_DIR="${HOME}/.config/toutui"
+    OS=$(identify_os)
+
+    load_dependencies
+    load_exit_codes
+
+    # Adjust script to OS
+    case $OS in
+        linux) DISTRO="$(get_distro)";;
+	macOS) DISTRO="hungry for apples?";;
+        *)     install_from_source;;
+    esac
+
+    case $1 in
+        --install|install) install_toutui && exit $EXIT_OK || exit $EXIT_FAIL;;
+        --update|update) update_toutui && exit $EXIT_OK || exit $EXIT_FAIL;;
+        *) usage "INCORRECT_ARG";;
+    esac
+}
+
+load_dependencies() {
+    # Hard Coded dependencies here.
+    # Dependencies starting with a '*' are optional
+    # Starting with "linux:" for all linux distros
+    # Starting with "macOS:" for macOS specific
+    # Starting with "debian: for debian only
+    # See also "arch:", "fedora:", "opensuse:", "centos:"
+    HC_DEPS=(
+	linux:curl \
+	linux:vlc  \
+	linux:pkg-config \
+	debian:libssl-dev \
+	linux:sqlite \
+	debian:libsqlite3-dev \
+	macOS:sqlite \
+	macOS:vlc \
+	macOS:curl \
+	macOS:pkg-config \
+	macOS:openssl \
+	*centos:epel-release \
+	*linux:kitty \
+	*macOS:kitty \
+	*macOS: netcat\
+	*debian:netcat \
+	*fedora:nc \
+	*centos:nc \
+	*arch:gnu-netcat \
+	*opensuse:netcat \
+	)
+}
+
+identify_os() {
+    case $OSTYPE in
+	darwin*) os="macOS";;
+	linux*)  os="linux";;
+	*) os="unknown";;
+    esac
+    echo $os
+}
+
+grab_username() {
+    local user=${USER:-$(whoami 2>/dev/null)}
+    user=${user:-$(id -un 2>/dev/null)}
+    if [[ -z "$user" ]]; then
+	echo "[ERROR] Cannot find username."
+	exit 1
+    fi
+    echo "$user"
+}
+
+grab_home_dir() {
+    local home=${HOME:-~/$USER}
+    if ! [[ -d "$home" ]]; then home=${home:-/home/$USER}; fi
+    if ! [[ -d "$home" ]]; then home=${home:-/Users/$USER}; fi
+    if ! [[ -d "$home" ]]; then
+	echo "[ERROR] Cannot find \"$USER\" home directory."
+	exit 1
+    fi
+    echo $home
+}
+
+usage() {
+    local exit_code=$1
+    echo "Usage: $ /bin/bash ./$(basename $0) <install|update>"
+    echo "Help:"
+    echo " --install: install toutui and dependencies."
+    echo " --update: update toutui and dependencies."
+    eval "exit \$EXIT_${exit_code}"
+}
+
+get_distro() {
+    local distro=$(head -n1 /etc/os-release 2>/dev/null| sed -E "s%.*\"([^\"]*).*\"%\1%")
+    if [[ -z $distro ]]; then distro=$(lsb_release -a 2>/dev/null | grep Description | sed "s/Description:\s*//") ;fi
+    if [[ -z $distro ]]; then distro=$(hostnamectl | grep "Operating System" | sed "s/Operating System:\s*//"); fi
+    if [[ -z $distro ]]; then distro="unknown"; fi
+    # rename distro to a lowercase general name (easier for package handling later)
+    case "$distro" in
+	Arch*) distro="archlinux";;
+    	Debian*|Ubuntu*) distro="debian";;
+    	Fedora*) distro="fedora";;
+    	CentOS*) distro="centos";;
+    	OpenSUSE*) distro="opensuse";;
+	unknown|*) distro="unknown";;
+    esac
+    echo "$distro"
+}
+
+install_from_source() {
+    echo "[ERROR] Could not identify OS/Distro."
+    echo "Please follow the instructions here:"
+    echo "https://github.com/AlbanDAVID/Toutui?tab=readme-ov-file#git"
+    exit $EXIT_UNKNOWN_OS
+}
+
+propose_optional_dependencies() {
+    local optionals="$@"
+    if (( ${#optionals[@]} == 0 )); then return; fi
+    echo "[INFO] Toutui's experience could be improved by these optional packages:"
+    for opt in "${optionals[@]}"; do
+        echo -e "\t- ${opt}"
+    done
+    local answer=
+    while :; do
+        read -p "Would you like to install these packages? (y/N) : " answer
+        if [[ $answer == "" || $answer =~ (n|N) ]]; then answer=no; break; fi
+        if [[ $answer =~ (y|Y) ]]; then answer=yes; break; fi
+    done
+    case $answer in
+        no)
+	   echo "[INFO] Ignoring optional dependencies.";;
+        yes)
+	   echo "[INFO] Installing optional dependencies."
+    	   install_packages "${optionals[@]}"
+	   echo "[OK] Optional dependencies installed."
+	   ;;
+    esac
+}
+
+install_rust() {
+    if ! [[ $(command -v rustc 2>/dev/null) ]]; then
+	echo "[INFO] Cannot find \"rustc\" in your \$PATH. Installing rust..."
+    	curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+    else
+	echo "[OK] \"rustc\" exists."
+    fi
+}
+
+install_packages() {
+    local dep="$@"
+    if (( ${#dep} == 0 )); then return; fi
+    case $OS in
+	linux)
+	    DISTRO=${DISTRO:-$(get_distro)}
+    	    case "$DISTRO" in
+    	        arch*) sudo pacman -S ${dep[@]};;
+    	        debian*) sudo apt install -y ${dep[@]};;
+    	        fedora*) sudo dnf install -y ${dep[@]};;
+    	        centos*) sudo yum install -y ${dep[@]};;
+    	        opensuse*) sudo zypper install -y ${dep[@]};;
+    	        *) install_from_source;;
+    	    esac ;;
+	macOS)
+	    if [[ $(command -v brew 2>/dev/null) ]]; then
+		brew install ${dep[@]}
+	    else
+		echo "[ERROR] Please install \"brew\"."
+		exit $EXIT_FAIL
+	    fi;;
+    esac
+    echo "[INFO] Packages installed successfully."
+}
+
+post_install_msg() {
+    if ! [[ -f "$CONFIG_DIR/.env" ]]; then
+	echo "[INFO] No secret found in .env. Do this:"
+    	echo "	$ mkdir -p ~/.config/toutui"
+    	echo "	$ echo 'TOUTUI_SECRET_KEY=secret' > ~/.config/toutui/.env"
+    fi
+}
+
+install_config() {
+    mkdir -p "$CONFIG_DIR" 2>/dev/null || ( echo "[ERROR] Cannot create config directory \"${CONFIG_DIR}\""; exit $EXIT_CONFIG )
+
+    # .env
+    local env="${CONFIG_DIR}/.env"
+    local prompt="Please provide a secret key for Toutui's credentials ($env): "
+    local key=
+    until [[ -f $env && $(sed "s/TOUTUI_SECRET_KEY=//g" $env) != "" ]]; do
+	## three possibilities here:
+	## 1) hide the secret with '*' (but no backspace allowed...)
+	#local char=
+	#while IFS= read -p "$prompt" -r -s -n 1 char; do
+	#    if [[ $char == $'\0' ]]; then echo; break; fi # return
+	#    prompt='*'
+	#    key+="$char"
+	#done
+	## 2) standard way: no '*' and no char displayed (backspace allowed)
+	read -sp "Please provide a secret key for toutui ($env): " key
+	## 3) clear secret displayed on screen
+	#read -p "Please provide a secret key for toutui ($env): " key
+        if ! [[ $key == "" ]]; then echo "TOUTUI_SECRET_KEY=$key" > $env; echo;fi
+    done
+
+    # config.
+    if ! [[ -f config.example.toml ]]; then
+	echo "[ERROR] \"config.example.toml\" not found."
+	exit $EXIT_CONFIG
+    else
+	cp config.example.toml "${CONFIG_DIR}/config.toml" || (echo "[ERROR] Cannot copy \"config.toml\"."; exit $EXIT_CONFIG)
+    fi
+}
+
+install_deps() {
+    # Grab dependencies and optional dependencies
+    # Optional deps start with "*" (e.g. *cvlc).
+    local deps=()
+    local optionals=()
+    if [[ -f deps.txt ]]; then
+	while read -r line; do
+	    if [[ $line == "" || $line =~ ^\# ]]; then continue; fi
+	    deps+=( "$line" )
+	done < deps.txt
+    else
+	deps=("${HC_DEPS[@]}")
+    fi
+
+    # Ignore already installed deps
+    # Keep track of optional deps
+    local missing=()
+    for dep in "${deps[@]}"; do
+	if [[ $dep =~ ^\* ]]; then
+	# those are optional dependencies
+	    deps=("${deps[@]/$dep}") # remove optional from deps
+	    dep="${dep:1:${#dep}}"
+	    # Check if package is for OS || distro
+	    # linux:XXX means for all distro
+	    # debian:XX means specific to debian/ubuntu
+	    if [[ "$dep" =~ ^($OS):(.*) ]]; then
+		target_sys=${BASH_REMATCH[1]}
+		dep=${BASH_REMATCH[2]}
+		# if OS or DISTRO match, add to optional deps
+		if [[ $target_sys == $OS || $target_sys == $DISTRO ]]; then
+		    # add only if not installed
+	    	    if ! [[ $(command -v $dep 2>/dev/null) ]]; then optionals+=( $dep ); fi
+		fi
+	    fi
+    	else
+	# those are essential dependencies
+	    if [[ "$dep" =~ ^($OS):(.*) ]]; then
+		target_sys=${BASH_REMATCH[1]}
+		dep=${BASH_REMATCH[2]}
+		# if OS or DISTRO match, add to optional deps
+		if [[ $target_sys == $OS || $target_sys == $DISTRO ]]; then
+		    # add only if not installed
+	    	    if ! [[ $(command -v $dep 2>/dev/null) ]]; then
+	    	        echo "[DEP] Missing dependency \"$dep\""
+    	    	        missing+=( $dep )
+    	    	    fi
+		fi
+	    fi
+    	fi
+    done
+    install_packages "${missing[@]}" && echo "[INFO] Essential dependencies are installed."
+    propose_optional_dependencies "${optionals[@]}"
+}
+
+install_toutui() {
+    install_deps # install essential and/or optional deps
+    install_rust # cornerstone! toutui is written by a crab
+    install_config # create ~/.config/toutui/ etc.
+    cargo run --release # actually install toutui
+    echo "[DONE] Install complete."
+    post_install_msg # only if .env not found
+}
+
+post_update_msg() {
+    echo "[DONE] Update complete."
+}
+
+get_toutui_local_release() {
+    if ! [[ -f Cargo.toml ]]; then
+	echo "[ERROR] Cannot find \"Cargo.toml\"."
+	exit $EXIT_NO_CARGO_TOML
+    fi
+    grep "version" Cargo.toml | head -1 | sed -E "s/^version\s*=\s*\"([^\"]*)\"\s*$/\1/"
+}
+
+get_toutui_github_release() {
+    curl -s https://api.github.com/repos/AlbanDAVID/Toutui/releases/latest | grep tag_name | sed -E "s|.*\"v([^\"]*)\",|\1|"
+}
+
+display_changelog() {
+    local changelog=$(curl -s https://api.github.com/repos/AlbanDAVID/Toutui/releases/latest | grep "\"body\"" | sed -E "s|^\s*\"body\":\s*\"([^\"]*)\"|\1|")
+    echo -e "\x1b[2m### CHANGELOG ###\x1b[0m"
+    echo -e "\x1b[2m$changelog\x1b[0m"
+    echo -e "\x1b[2m#################\x1b[0m"
+}
+
+pull_latest_version() {
+    local version=$1
+    local answer=
+    while :; do
+	read -p "Would you like to pull the latest version? (Y/n) : " answer
+	if [[ $answer =~ (n|N) ]]; then answer=no; break; fi
+	if [[ $answer == "" || $answer =~ (y|Y) ]]; then answer=yes; break; fi
+    done
+    case $answer in
+	no)
+	    echo "[INFO] Ignoring latest version.";;
+	yes)
+	    echo "[INFO] Pulling latest version..."
+	    git fetch && git pull
+	    echo "[INFO] Installing latest version..."
+	    cargo run --release
+	    echo "[OK] Latest version installed (v$version)."
+	    ;;
+    esac
+}
+
+update_toutui() {
+    install_deps # check for new deps
+    local local_release=$(get_toutui_local_release)
+    local github_release=$(get_toutui_github_release)
+    if [[ $local_release == $github_release ]]; then
+	echo "[INFO] Up to date (version $local_release)."
+    else
+	#echo "TODO: check if is behind or ahead?"
+	display_changelog # display before pulling?
+	pull_latest_version $github_release
+    fi
+    post_update_msg
+}
+
+load_exit_codes() {
+    # Exit codes for convenience?
+    EXIT_OK=0
+    EXIT_FAIL=1
+    EXIT_ROOT=2
+    EXIT_UNKNOWN_OS=3
+    EXIT_INCORRECT_ARG=4
+    EXIT_NO_CARGO_TOML=5
+    EXIT_CONFIG=6
+}
+
+do_not_run_as_root() {
+    # Must not be run as root
+    if [[ $EUID == 0 ]]; then
+        echo "[ERROR] Do not run this script as root."
+        exit $EXIT_ROOT
+    fi
+}
+
+main "$@"


### PR DESCRIPTION
<!--
Thx for you PR :)
-->

## Brief summary

A script to facilitate installing Toutui and its dependencies.
Flexible.
For Linux and macOS.

## Which issue is fixed?

None.

## In-depth Description

<!--
Describe your solution in more depth.
How does it work? Why is this the best solution?
Does it solve a problem that affects multiple users or is this an edge case for your setup?
-->

The script can either install or update Toutui.
It works on different Linux distributions (Arch,Debian,Ubuntu,...) and macOS.

`sh ./hello_toutui.sh --install` automatizes the installation of Toutui and its dependencies.
`sh ./hello_toutui.sh --update` compares and update Toutui's local version to the GitHub's latest release.

Dependencies' list is made simple to hard-code.
For example, adding `*debian:kitty` will check for an optional (`*`) dependency (`kitty`), only on Debian/Ubuntu (`debian:`).

If hard-coding is unwanted, `hello_toutui.sh` will read a `./deps.txt` file when placed in the same directory. It contains specifically formated packages names. Here is a self-documenting example:

```console
# this is a comment
# "os:package_name" or "distro:package_name"

# OS specific packages
# Use: "linux:" or "macOS:"
# ---
linux:curl
linux:vlc
linux:pkg-config
linux:sqlite
macOS:sqlite
macOS:vlc
macOS:curl
macOS:pkg-config
macOS:openssl

# Distro specific packages
# Use: "arch:", "debian:", "fedora:", "centos:", "opensuse:"
# ---
debian:libssl-dev
debian:libsqlite3-dev

# Optional dependencies
# Use: "*" in front of OS/distro
# ---
*linux:kitty
*linux:netcat
*centos:epel-release
*macOS:kitty
*macOS: netcat
*debian:netcat
*fedora:nc
*centos:nc
*arch:gnu-netcat
*opensuse:netcat
```

## How have you tested this?

By typing things on my computer <| :^)
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; (tested on arch and debian)

## Screenshots

![converted](https://github.com/user-attachments/assets/e1cd844c-9e40-4a52-87b4-e6d7e51dd2c6)