### PR TITLE
feat: macos build

### DIFF
--- a/src/api/libraries/get_all_libraries.rs
+++ b/src/api/libraries/get_all_libraries.rs
@@ -55,7 +55,9 @@ pub struct Settings {
     pub hide_single_book_series: Option<bool>,
     pub only_show_later_books_in_continue_series: Option<bool>,
     pub metadata_precedence: Option<Vec<String>>,
+    #[serde(default)]
     pub mark_as_finished_percent_complete: Value,
+    #[serde(default)]
     pub mark_as_finished_time_remaining: i64,
     pub podcast_search_region: Option<String>,
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -442,10 +442,13 @@ impl App {
     // init start_vlc variables
     let is_cvlc = config.player.cvlc.clone();
     let is_cvlc_term = config.player.cvlc_term.clone();
-    let mut start_vlc_program = "vlc".to_string();
-    if is_cvlc == "1" {
-        start_vlc_program = "cvlc".to_string()
-    } 
+    let mut start_vlc_program = match is_cvlc.as_str() {
+        "1" => "cvlc".to_string(),
+        _ => "vlc".to_string(),
+    };
+    if cfg!(target_os = "macos") {
+        start_vlc_program = "/Applications/VLC.app/Contents/MacOS/VLC".to_string();
+    }
 
     // Init ListeState for `Home` list (continue listening)
     let mut list_state_cnt_list = ListState::default(); // init the ListState ratatui's widget


### PR DESCRIPTION
<!--
Thx for you PR :)
-->

## Brief summary

This PR changes a few directory paths to allow for toutui to build on macOS.

## Which issue is fixed?

- fixed the CONFIG_DIR and binary paths
- mark_as_finished_percent_complete was missing in the HTTP response, made it defaulting
- vlc/cvlc is invalid on macos. Use the brew binary path instead

<!-- Which issue number does this PR fix? Ex: "Fixes #1234" -->

## In-depth Description

<!--
Describe your solution in more depth.
How does it work? Why is this the best solution?
Does it solve a problem that affects multiple users or is this an edge case for your setup?
-->

## How have you tested this?

<!-- Please describe in detail with reproducible steps how you tested your changes. -->
Ran on macos and arch linux
## Screenshots

<!-- If your PR includes any changes to the UI, please include screenshots or a short video from before and after your changes. -->
