### PR TITLE
Support custom install path for `hello_toutui.sh`

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,12 @@ echo TOUTUI_SECRET_KEY=secret >> ~/.config/toutui/.env
 ```bash
 cargo run --release
 ```
+
+To install in a custom location, provide the path like this:
+```console
+./hello_toutui.sh install /usr/bin
+```
+
 #### **Update**
 
 When a new release is available, follow these steps:


### PR DESCRIPTION
<!--
Thx for you PR :)
-->

## Brief summary

- Allow custom install path
- Handy functions to adapt config and install directories to OS
- Minor fixes

## Which issue is fixed?

None.

## In-depth Description

<!--
Describe your solution in more depth.
How does it work? Why is this the best solution?
Does it solve a problem that affects multiple users or is this an edge case for your setup?
-->

- `sh ./hello_toutui.sh install /usr/local/bin` will install `toutui` in `/usr/local/bin`. Default directory for Linux : `/usr/bin`. Default directory for macOS: `/usr/local/bin`.
- Different functions to find home, config and install directories could allow more flexibility when adding support for other distributions/OS. 

## How have you tested this?

Tested on Arch and Debian.

## Screenshots

<!-- If your PR includes any changes to the UI, please include screenshots or a short video from before and after your changes. -->
![noah](https://github.com/user-attachments/assets/fbf7dcac-be8e-432f-9e7d-83bb0695e5b0)
