### PR TITLE
added flake for nix users

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1765186076,
+        "narHash": "sha256-hM20uyap1a0M9d344I692r+ik4gTMyj60cQWO+hAYP8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "addf7cf5f383a3101ecfba091b98d0a1263dc9b8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,63 @@
+{
+  description = "Toutui - A TUI Audiobookshelf client for Linux and macOS";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+      in
+      {
+        packages.default = pkgs.rustPlatform.buildRustPackage {
+          pname = "toutui";
+          version = "0.4.2-beta";
+          
+          src = ./.;
+          
+          cargoLock.lockFile = ./Cargo.lock;
+          
+          # Build-time dependencies
+          nativeBuildInputs = with pkgs; [ 
+            pkg-config 
+            perl
+            makeWrapper  # Provides wrapProgram
+          ];
+          
+          # Runtime dependencies
+          buildInputs = with pkgs; [ 
+            openssl
+            vlc 
+          ];
+          
+          # netcat needed at runtime
+          postInstall = ''
+            wrapProgram $out/bin/toutui \
+              --prefix PATH : ${pkgs.lib.makeBinPath [ pkgs.netcat ]}
+          '';
+
+          meta = with pkgs.lib; {
+            description = "TUI Audiobookshelf client for Linux and macOS";
+            homepage = "https://github.com/AlbanDAVID/Toutui";
+            license = licenses.gpl3Only;
+            maintainers = [ ];
+            platforms = platforms.unix;
+          };
+        };
+
+        devShells.default = pkgs.mkShell {
+          buildInputs = with pkgs; [
+            cargo
+            rustc
+            openssl
+            vlc
+            netcat
+            pkg-config
+            perl
+          ];
+        };
+      });
+}


### PR DESCRIPTION
## Brief summary
added a flake.nix file so users of both nix and nixos can quickly and easily get toutui installed and running allowing for another method of installation

## How have you tested this?
tested via nix build and ran locally

